### PR TITLE
Fix support zend-diactoros.

### DIFF
--- a/src/MiddlewareCors.php
+++ b/src/MiddlewareCors.php
@@ -280,14 +280,14 @@ class MiddlewareCors
             $headers['Access-Control-Expose-Headers'] = $exposeHeaders;
         }
 
+        // return the next bit of middleware
+        $response = $next($request, $response);
+
         foreach ($headers as $k => $v) {
             $response = $response->withHeader($k, $v);
         }
-
         $this->addLog('Calling next bit of middleware');
-        // return the next bit of middleware
-        $next = $next($request, $response);
 
-        return $next;
+        return $response;
     }//end __invoke()
 }//end class


### PR DESCRIPTION
I'm using expressive and zend-diactoros compoenet.
There's no CORS headers response.

### Code to reproduce the issue

```php
//Slim/Expressive using zend-diactoros 
$app->get('/test', function (ServerRequestInterface $request) {
    return new \Zend\Diactoros\Response\JsonResponse([]);
});
```

### Expected results

HTTP response steam:

```
HTTP/1.1 200 OK
Content-Type: application/json
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://localhost


[]
```

### Actual results

HTTP response steam:

```
HTTP/1.1 200 OK
Content-Type: application/json

[]
```