### PR TITLE
fixed count expression (before; the array_search never finds anything)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $corsAllowedMethods = function (ServerRequestInterface $request) use ($container
     }
 
     // if we have methods, let's list them removing the OPTIONs one.
-    if (0 === count($methods)) {
+    if (0 !== count($methods)) {
         // find the OPTIONs method
         $key = array_search('OPTIONS', $methods,true);
         // and remove it if set.


### PR DESCRIPTION
The original code checks first that there are no methods then tries to find the option which should never find anything. No should correctly work.

The code was :

```
if (0 === count($methods)) {
        // find the OPTIONs method
        $key = array_search('OPTIONS', $methods,true);
}

```
